### PR TITLE
Limited scope of aw_blog SQL injection bug.

### DIFF
--- a/connect20/aw_blog/CVE-2015-3428.yaml
+++ b/connect20/aw_blog/CVE-2015-3428.yaml
@@ -4,5 +4,5 @@ cve:       CVE-2015-3428
 branches:
     1.x:
         time:     2015-05-27 12:00:00
-        versions: [>=1.3.9,<1.3.10]
+        versions: [>=1.3.8,<1.3.10]
 reference: composer://connect20/aw_blog

--- a/connect20/aw_blog/CVE-2015-3428.yaml
+++ b/connect20/aw_blog/CVE-2015-3428.yaml
@@ -4,5 +4,5 @@ cve:       CVE-2015-3428
 branches:
     1.x:
         time:     2015-05-27 12:00:00
-        versions: [<1.3]
+        versions: [1.3.8,1.3.9]
 reference: composer://connect20/aw_blog

--- a/connect20/aw_blog/CVE-2015-3428.yaml
+++ b/connect20/aw_blog/CVE-2015-3428.yaml
@@ -4,5 +4,5 @@ cve:       CVE-2015-3428
 branches:
     1.x:
         time:     2015-05-27 12:00:00
-        versions: [1.3.8,1.3.9]
+        versions: [>=1.3.9,<1.3.10]
 reference: composer://connect20/aw_blog


### PR DESCRIPTION
As was established by my colleagues who tested and downloaded all AW Blog versions <= 1.3.10.
https://www.byte.nl/blog/lek-aheadworks-blog-extensie-voor-magento
